### PR TITLE
feat: different badge styling

### DIFF
--- a/src/style/content.less
+++ b/src/style/content.less
@@ -1,14 +1,24 @@
 .user-pronoun {
-    padding: 2px;
+    line-height: 1.15rem;
+    height: 18px;
     font-weight: bold;
-    border-radius: 5px;
-    color: var(--color-text-base);
-    border: 1px solid var(--color-text-base);
+    font-size: 1rem;
+    padding: 4px;
+    padding-top: 3px;
+    background: var(--color-background-brand);
+    color: var(--color-hinted-grey-1);
+    border-radius: 3px;
+}
+
+.tw-root--theme-light .user-pronoun {
+    background: var(--color-hinted-grey-12);
 }
 
 .pr-badge-wrapper[data-a-target="pr-badge-cnt"][data-provider="pronouns.alejo.io"] {
-    display: inline !important;
-    position: relative !important;
+    float: left;
+    position: relative;
+    margin-right: .3rem;
+    margin-top: .15rem;
 }
 
 .pr-badge-wrapper:hover > .pr-tooltip {

--- a/src/ts/pronounBadge.ts
+++ b/src/ts/pronounBadge.ts
@@ -2,7 +2,7 @@
 export function generatePronounBadge(text: string): HTMLElement {
 	let textSpan = document.createElement('span');
 	{
-		textSpan.setAttribute('class', 'chat-badge user-pronoun')
+		textSpan.setAttribute('class', 'user-pronoun')
 		textSpan.setAttribute('data-a-target', 'pr-badge-txt')
 		textSpan.textContent = text;
 	}


### PR DESCRIPTION
This is pretty subjective but I wanted to style the badges a bit differently, let me know if you're interested.

1. Moved badge to the left, this also might helps solve #10 and #6
2. Reduced font size, made the badge 18px to match the other badges

**Before:**
![image](https://user-images.githubusercontent.com/2591901/128786756-51e64b62-1875-4e58-a616-1ed16a93220a.png)

![image](https://user-images.githubusercontent.com/2591901/128786786-3d4a8738-d97c-4854-ac70-634548230f3b.png)


**After:**

![image](https://user-images.githubusercontent.com/2591901/128786583-5c951918-1acb-416f-9b9c-1fab9d786765.png)

![image](https://user-images.githubusercontent.com/2591901/128786604-56e76126-d088-4638-969f-292fef8b72b1.png)
