### PR TITLE
Cache user pronouns to avoid repeated network calls

### DIFF
--- a/src/ts/api/pronouns.alejo.io.ts
+++ b/src/ts/api/pronouns.alejo.io.ts
@@ -1,6 +1,9 @@
 import Pronoun, { IPronouns } from "../types/pronouns";
 import { IUser } from "../types/users";
 
+const userPronounsCache: Record<string,string> = {
+}
+
 async function get<T = JSON>(endpoint: string): Promise<T> {
 	return await fetch(process.env.BASE_API_URL + endpoint).then(async (res: Response) => {
 		return res.json() as Promise<T>;
@@ -21,12 +24,18 @@ export async function getUserPronoun(username: string): Promise<string | undefin
 		return;
 	}
 
+	const cachedPronoun = userPronounsCache[username]
+	if (cachedPronoun) {
+		return cachedPronoun
+	}
+
 	var res = await get<IUser[]>("users/" + username);
 	let match: IUser | undefined = res.find((user: IUser) => {
 		return user.login.toLowerCase() === username.toLowerCase();
 	})
 
 	if (match !== undefined) {
+		userPronounsCache[username] = match.pronoun_id
 		return match.pronoun_id;
 	}
 }

--- a/src/ts/api/pronouns.alejo.io.ts
+++ b/src/ts/api/pronouns.alejo.io.ts
@@ -1,7 +1,10 @@
 import Pronoun, { IPronouns } from "../types/pronouns";
 import { IUser } from "../types/users";
 
-const userPronounsCache: Record<string,string> = {
+type PronounValue = {
+	value?: string
+}
+const userPronounsCache: Record<string, PronounValue> = {
 }
 
 async function get<T = JSON>(endpoint: string): Promise<T> {
@@ -26,7 +29,7 @@ export async function getUserPronoun(username: string): Promise<string | undefin
 
 	const cachedPronoun = userPronounsCache[username]
 	if (cachedPronoun) {
-		return cachedPronoun
+		return cachedPronoun.value
 	}
 
 	var res = await get<IUser[]>("users/" + username);
@@ -34,8 +37,11 @@ export async function getUserPronoun(username: string): Promise<string | undefin
 		return user.login.toLowerCase() === username.toLowerCase();
 	})
 
+	userPronounsCache[username] = {
+		value: match?.pronoun_id
+	}
+
 	if (match !== undefined) {
-		userPronounsCache[username] = match.pronoun_id
 		return match.pronoun_id;
 	}
 }


### PR DESCRIPTION
Great work on this extension! I heard about it a few times from other streamers/viewers and thought I'd use it. 

I made these changes on my fork to optimize networking, for my own preferences. If this interests you, feel free to merge. If not, no hard feelings.

The following changes cache the pronouns for a user. They are cached even if your server returns no pronouns for a username. If I send 10 messages, only 1 network request will go out to fetch my pronouns, not 10, whether I have pronouns registered on your site or not.

If I'm running this while I am streaming, for example, the main drawbacks are the following:

- if a viewer joins the plugin mid-stream, I won't get their pronouns unless I refresh my stream manager 
- if a viewer changes their pronouns mid-stream, I won't get their updated pronouns unless I refresh my stream manager


## Network savings

To run the numbers against my last stream, I had 319 messages sent in chat, compared to 34 unique chatters. If I mathed it correctly, it looks like these changes would save me 285 network calls. It should, in theory, make 35 calls if starting with an empty chat:

- 1 to fetch the pronouns list
- 34 username calls, 1 for each unique chatter

This is worth it for me since I don't have the best internet, but it may not be worth it for your users, so merge only at your discretion.